### PR TITLE
feat: あいことば変更機能を追加し、エラーメッセージをトースト通知に変更

### DIFF
--- a/frontend/src/components/settings/AccountSettings.jsx
+++ b/frontend/src/components/settings/AccountSettings.jsx
@@ -33,7 +33,7 @@ export const AccountSettings = ({ setActiveTab }) => {
             }
         };
         fetchProfile();
-    }, []);
+    }, [navigate]);
 
     // パスワード変更処理
     const handlePasswordChange = async () => {

--- a/frontend/src/components/settings/ChildSettings.jsx
+++ b/frontend/src/components/settings/ChildSettings.jsx
@@ -26,8 +26,8 @@ export const ChildSettings = ({ setActiveTab }) => {
             const response = await apiClient.get(CHILDREN_LIST);
             setChildren(response.data.children);
             setSelectedChild(response.data.children[0]);
-        } catch (error) {
-            console.error("子供情報取得エラー:", error);
+        } catch {
+            toast.error("子供情報取得エラー");
         }
     };
 

--- a/frontend/src/components/settings/ChildSettings.jsx
+++ b/frontend/src/components/settings/ChildSettings.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { CustomButton } from "../common/CustomButton";
 import { InputField } from "../common/InputField";
 import { Select } from "../common/Select";
-import { CHILDREN_BASE, CHILDREN_LIST, CHILD_LOGIN_URL } from "../../config/api";
+import { CHILDREN_BASE, CHILDREN_LIST, CHILD_LOGIN_URL, KEYWORD_CHANGE } from "../../config/api";
 import { apiClient } from "../../lib/apiClient";
 import { Modal } from "../ui/Modal";
 import { toast, ToastContainer } from "react-toastify";
@@ -14,6 +14,7 @@ export const ChildSettings = ({ setActiveTab }) => {
     const [children, setChildren] = useState([]);
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [newChildName, setNewChildName] = useState("");
+    const [isSaving, setIsSaving] = useState(false);
 
     // 子供全取得
     useEffect(() => {
@@ -58,8 +59,24 @@ export const ChildSettings = ({ setActiveTab }) => {
     };
 
     // 決定ボタン
-    const handleSubmitClick = (e) => {
+    const handleSubmitClick = async (e) => {
         e.preventDefault();
+
+        if (!keyword.trim()) {
+            toast.error("あいことばを入力してください");
+            return;
+        }
+        try {
+            setIsSaving(true);
+            await apiClient.post(KEYWORD_CHANGE, { newKeyword: keyword });
+
+            toast.success("あいことばを更新しました");
+            setKeyword("");
+        } catch {
+            toast.error("あいことばの更新に失敗しました")
+        } finally {
+            setIsSaving(false);
+        }
     };
 
     // コピーボタン
@@ -70,7 +87,7 @@ export const ChildSettings = ({ setActiveTab }) => {
         navigator.clipboard
             .writeText(url)
             .then(() => {
-                toast.success("URLをコピーしました ✅");
+                toast.success("URLをコピーしました");
             })
             .catch(() => {
                 toast.error("コピーに失敗しました");
@@ -148,6 +165,7 @@ export const ChildSettings = ({ setActiveTab }) => {
                         type="button"
                         label="決定"
                         onClick={handleSubmitClick}
+                        disabled={isSaving}
                         className="w-30 h-12 bg-orange-300 text-black text-2xl font-extrabold rounded-lg hover:bg-orange-200
                       transition-colors duration-300"
                     />

--- a/frontend/src/components/settings/SalarySettings.jsx
+++ b/frontend/src/components/settings/SalarySettings.jsx
@@ -45,7 +45,7 @@ export const SalarySettings = ({ setActiveTab }) => {
       }
     };
     fetchSettings();
-  }, []);
+  }, [navigate]);
 
   const handlePaydayChange = (e) => {
     setSelectedPayday(e.target.value);

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -41,3 +41,4 @@ export const INIT_SETUP = `${API_BASE_URL}/api/setup`;
 export const PARENT_EMAIL_CHANGE = `${API_BASE_URL}/email`; // メールアドレス変更
 export const PARENT_EMAIL_GET = `${API_BASE_URL}/api/setting/`; // メールアドレス取得
 export const PAYDAY_CUTOFF_SETTING = `${API_BASE_URL}/api/setting/paycut`;	  // 締め日給料日設定
+export const KEYWORD_CHANGE = `${API_BASE_URL}/api/setting/change`; // あいことば変更

--- a/frontend/src/pages/ChildSignup.jsx
+++ b/frontend/src/pages/ChildSignup.jsx
@@ -33,7 +33,7 @@ export const ChildSignup = () => {
       });
       
       navigate('/ChildUrl',{ state: { childId: response.data.user_id } });
-    } catch (error) {
+    } catch {
       toast.error("子供のアカウント作成に失敗しました")
     }
   };

--- a/frontend/src/pages/ChildSignup.jsx
+++ b/frontend/src/pages/ChildSignup.jsx
@@ -5,6 +5,8 @@ import { Link, useNavigate } from "react-router-dom";
 import { getToken } from "../config/Token";
 import { INIT_SETUP } from "../config/api";
 import { apiClient } from "../lib/apiClient";
+import { toast, ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 export const ChildSignup = () => {
   const [c_name, setName] = useState('');
@@ -13,14 +15,14 @@ export const ChildSignup = () => {
 
   const handleSignup = async () => {
     if (!c_name || !keyword) {
-      alert('入力エラー', '入力してください');
+      toast.error("名前とあいことばを入力してください")
       return;
     }
 
     const token = getToken();
 
     if (!token) {
-      alert('親アカウントからやり直してください。');
+      toast.error("親のアカウントからやり直してください")
       return;
     }
     try {
@@ -30,14 +32,14 @@ export const ChildSignup = () => {
         keyword,
       });
       
-      console.log('登録成功:', response.data);
       navigate('/ChildUrl',{ state: { childId: response.data.user_id } });
     } catch (error) {
-      console.error('エラー:', error);
+      toast.error("子供のアカウント作成に失敗しました")
     }
   };
   return (
       <div className="bg-orange-100 h-screen">
+        <ToastContainer />
         <h1 className="text-6xl font-bold text-center w-full py-25">子供用アカウント作成</h1>
         <form className="space-y-4">
           <div className="flex flex-col items-center justify-center space-y-4">
@@ -48,8 +50,9 @@ export const ChildSignup = () => {
               onChange={e => setName(e.target.value)}
               className="mb-12 w-150 h-15 px-4 border rounded-lg bg-gray-100"
             />
+            <p className="text-3xl font-bold text-center pb-10">あいことばを入力してください</p>
             <InputField
-              type="password"
+              type="text"
               value={keyword}
               onChange={e => setKeyword(e.target.value)}
               className="mb-12 w-150 h-15 px-4 border rounded-lg bg-gray-100"

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -5,6 +5,8 @@ import { Link, useNavigate } from "react-router-dom"
 import { setToken } from "../config/Token";
 import { apiClient } from "../lib/apiClient";
 import { PARENT_LOGIN } from "../config/api";
+import { toast, ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 export const Login = () => {
   const [email, setEmail] = useState('');
@@ -12,10 +14,21 @@ export const Login = () => {
   const navigate = useNavigate();
 
   const handleLogin = async () => {
-    if (!email || !password) {
-      alert('入力エラー', 'メールアドレスとパスワードを入力してください');
+    if (!email.trim()) {
+      toast.error("メールアドレスを入力してください")
       return;
     }
+    const emailOk = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+    if (!emailOk) {
+      toast.error("メールアドレスの形式が正しくありません");
+      return;
+    }
+    if (!password) {
+      toast.error("パスワードを入力してください");
+      return;
+    }
+
+
     try {
       const response = await apiClient.post(PARENT_LOGIN,
         {
@@ -26,8 +39,8 @@ export const Login = () => {
       const Token = response.data.token;
       setToken(Token);
       navigate('./top', { state: { token: setToken(Token) } });
-    } catch (error) {
-      console.error('ログインエラー:', error);
+    } catch {
+      toast.error("メールアドレスまたはパスワードが正しくありません");
     }
   };
 
@@ -35,6 +48,7 @@ export const Login = () => {
 
   return (
     <div className="bg-orange-100 h-screen">
+      <ToastContainer/>
       <h1 className="text-6xl font-bold text-center w-full py-30">ログイン</h1>
       <form>
         <div className="flex flex-col items-center justify-center space-y-4">

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CustomButton } from "../components/common/CustomButton"
 import { InputField } from "../components/common/InputField"
 import { Link, useNavigate } from "react-router-dom"
-import { setToken } from "../config/Token";
+import { getToken, setToken } from "../config/Token";
 import { apiClient } from "../lib/apiClient";
 import { PARENT_LOGIN } from "../config/api";
 import { toast, ToastContainer } from "react-toastify";
@@ -12,6 +12,14 @@ export const Login = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const navigate = useNavigate();
+
+  // ログインスキップ
+  useEffect(() => {
+    const token = getToken();
+    if (token) {
+      navigate("/top", { replace: true });
+    }
+  }, [navigate]);
 
   const handleLogin = async () => {
     if (!email.trim()) {

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -28,7 +28,7 @@ export const SignupPage = () => {
       setToken(Token);
       console.log('登録成功:', response.data);
       navigate('/childName');
-    } catch (error) {
+    } catch {
       let msg = "登録に失敗しました";
       const data = error?.response?.data;
 

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
 import { CustomButton } from "../components/common/CustomButton";
 import { InputField } from "../components/common/InputField";
-import {useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { apiClient } from "../lib/apiClient";
 import { PARENT_SIGNUP } from "../config/api";
 import { setToken } from "../config/Token";
+import { toast, ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 export const SignupPage = () => {
   const [email, setEmail] = useState('');
@@ -13,7 +15,7 @@ export const SignupPage = () => {
 
   const handleSignup = async () => {
     if (!email || !password) {
-      alert('メールアドレスとパスワードを入力してください');
+      toast.error("メールアドレスとパスワードを入力してください");
       return;
     }
 
@@ -27,12 +29,27 @@ export const SignupPage = () => {
       console.log('登録成功:', response.data);
       navigate('/childName');
     } catch (error) {
-      console.error('エラー:', error);
+      let msg = "登録に失敗しました";
+      const data = error?.response?.data;
+
+      if (typeof data === "string") {
+        try {
+          const parsed = JSON.parse(data);
+          msg = parsed?.message || parsed?.error || parsed?.detail || data;
+        } catch {
+          msg = data; // 素の文字列
+        }
+      } else if (data && typeof data === "object") {
+        msg = data.message || data.error || data.detail || msg;
+      }
+
+      toast.error(msg);
     }
   };
 
   return (
     <div className="bg-orange-100 h-screen">
+      <ToastContainer />
       <h1 className="text-6xl font-bold text-center w-full py-25">アカウント作成</h1>
       <form className="space-y-4">
         <div className="flex flex-col items-center justify-center space-y-4">
@@ -61,7 +78,7 @@ export const SignupPage = () => {
               className="w-50 h-15 bg-gray-300 text-black text-2xl font-extrabold rounded-lg hover:bg-gray-200
             transition-colors duration-300 mt-4"
             />
-            
+
             <CustomButton
               type="button"
               label="作成"


### PR DESCRIPTION
close #295 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toast notifications replaced alerts across Login, Signup, and Child Signup; ToastContainers added for consistent Japanese feedback.
  * Email format and required-field validation show descriptive toasts before submission.
  * Auto-skip login when a session exists (navigates to top).
  * Child Signup shows a passphrase prompt and plain-text keyword input.
  * Child Settings: keyword update with validation, success/error toasts, and save button disabled while saving.

* **Style**
  * Copy-URL toast text changed to “URLをコピーしました”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->