### PR TITLE
fix: パスワードリセット機能にトークンの取得とヘッダー設定を追加

### DIFF
--- a/frontend/src/pages/PasswordReset.jsx
+++ b/frontend/src/pages/PasswordReset.jsx
@@ -1,14 +1,20 @@
+
 import { useState } from "react";
-import { InputField } from "../components/common/InputField"
+import { InputField } from "../components/common/InputField";
 import { CustomButton } from "../components/common/CustomButton";
 import { PASS_RESET } from "../config/api";
 import { apiClient } from "../lib/apiClient";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 
 export const PasswordReset = () => {
+
     const [newPassword, setNewPassword] = useState('');
     const [confirmNewPassword, setConfirmNewPassword] = useState('');
     const navigate = useNavigate();
+    const location = useLocation();
+
+    const searchParams = new URLSearchParams(location.search);
+    const token = searchParams.get('token');
 
     const handleSubmitClick = async () => {
         if (!newPassword || !confirmNewPassword) {
@@ -19,8 +25,16 @@ export const PasswordReset = () => {
             return;
         }
 
+        if (!token) {
+            return;
+        }
+
         try {
-            await apiClient.post(PASS_RESET, { newPassword });
+            await apiClient.post( PASS_RESET, { newPassword }, {
+              headers: {
+              Authorization: `Bearer ${token}`, 
+              },
+            });
             navigate("/");
         } catch (error) {
             console.error("リセットエラー:", error);
@@ -55,5 +69,5 @@ export const PasswordReset = () => {
                 />
             </div>
         </div>
-    )
-}
+    );
+};


### PR DESCRIPTION
close #306 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Password reset now correctly reads the token from the reset link and only proceeds when it’s present, reducing failed attempts.
  * Requests include proper authorization, improving reliability and security of the reset process.
  * Maintains redirect to the home page on success; clearer handling when the token is missing.

* **Style**
  * Minor formatting cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->