### PR TITLE
ChildSidebarコンポーネントのスタイルを修正し、固定位置を調整しました。

### DIFF
--- a/frontend/src/components/ui/SidebarItem.jsx
+++ b/frontend/src/components/ui/SidebarItem.jsx
@@ -23,7 +23,7 @@ const itemClasses = `
     return (
         <li className={`list-none ${itemClasses}`} onClick={onClick}>
             <span className="hidden md:inline md:mr-6 md:text-2xl">{renderIcon()}</span>
-            <span className={`md:hidden text-[17px] font-semibold text-b px-1 py-2  rounded ${getMobileConfig().bg} writing-vertical-rl inline-block h-23 text-center mt-12 ml-1`}  style={{ userSelect: 'none', WebkitTapHighlightColor: 'transparent' }}>
+            <span className={`md:hidden text-[13px]   font-semibold  px-1 py-1  rounded ${getMobileConfig().bg} writing-vertical-rl inline-block h-14 text-center mt-12 `}  style={{ userSelect: 'none', WebkitTapHighlightColor: 'transparent' }}>
                 {getMobileConfig().label}  
             </span>
             <span className="hidden md:block text-3xl font-semibold text-black">

--- a/frontend/src/components/ui/child/ChildSidebar.jsx
+++ b/frontend/src/components/ui/child/ChildSidebar.jsx
@@ -9,7 +9,7 @@ export const ChildSidebar = ({ activeMenuItem, onMenuItemClick }) => {
 
     return (
         <aside className="
-            fixed top-0 left-0 w-full flex flex-row justify-start px-10 z-50
+            fixed top-12 left-0 w-full flex flex-row justify-start px-10 z-50
             md:relative md:w-80 md:bg-orange-100 md:text-white md:p-4 md:h-full md:flex md:flex-col
         ">
             <nav>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Refined mobile sidebar label appearance with smaller text, reduced padding and height, and cleaner spacing for a more compact layout.
  - Preserved existing icons and behavior; only visual presentation was updated.
  - Adjusted the child sidebar’s vertical offset to better align with header content and overall layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->