### PR TITLE
docs: backend・frontend の README を更新

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,18 +1,151 @@
-backend でターミナル開く
-//Ctrl-Y\backend>
+# backend — ご褒美ポケット API サーバー
 
-//npm 入れる
-npm i
+Express + Node.js で構築された REST API サーバーです。親子タスク管理・給与集計・認証・通知機能を提供します。
 
-↓
+## 技術スタック
 
-//prisma クライアント作成
-//スキーマ変更時
-doppler run -- npx prisma generate
+| 技術 | バージョン | 用途 |
+|------|-----------|------|
+| Express | 5.x | Web フレームワーク |
+| Node.js | v18+ | ランタイム |
+| Prisma | 6.x | ORM |
+| PostgreSQL | — | データベース（Supabase） |
+| JWT | 9.x | 認証トークン |
+| bcrypt | 6.x | パスワードハッシュ |
+| nodemailer | 7.x | メール送信（Gmail） |
+| node-cron | 4.x | 月次給与集計ジョブ |
+| web-push | 3.x | プッシュ通知 |
 
-↓
+## ディレクトリ構成
 
-//サーバ起動
-doppler run -- npm run dev
-or
+```
+backend/
+├── prisma/
+│   └── schema.prisma        # データモデル定義
+├── src/
+│   ├── controllers/         # HTTPリクエスト/レスポンス処理
+│   │   └── tasks/           # タスク操作（get/post/patch/del/stats）
+│   ├── routes/              # APIルート定義
+│   ├── services/            # ビジネスロジック層
+│   │   └── tasks/
+│   ├── middlewares/         # 認証・認可ミドルウェア
+│   │   ├── auth.js          # JWT 検証
+│   │   └── parentOnly.js    # 親アカウント専用制限
+│   ├── lib/                 # 共通ライブラリ
+│   │   ├── prisma.js        # Prisma クライアント（@db エイリアス）
+│   │   ├── jwt.js           # JWT 操作
+│   │   ├── mail.js          # メール送信
+│   │   ├── cors.js          # CORS 設定
+│   │   └── cron.js          # 月次集計ジョブ
+│   ├── utils/               # 汎用ヘルパー
+│   │   ├── AppError.js      # カスタムエラークラス
+│   │   ├── responseHandler.js
+│   │   ├── parseUtils.js
+│   │   └── taskAuthUtils.js # タスク認可ヘルパー
+│   └── index.js             # Express アプリ設定
+├── server.js                # エントリーポイント
+├── swagger.json             # OpenAPI 仕様
+└── nodemon.json
+```
+
+## セットアップ
+
+### 1. 依存パッケージのインストール
+
+```bash
+npm install
+```
+
+### 2. 環境変数の設定
+
+`.env` ファイルをルートに作成し、以下の変数を設定してください。
+
+```env
+# データベース
+DATABASE_URL=postgresql://user:password@host:5432/dbname
+SB_URL=https://xxx.supabase.co
+SB_CONNECT=postgresql://...     # Supabase 直接接続 URL
+
+# 認証
+JWT_SECRET=your-secret-key
+
+# サーバー
+PORT=3000
+API_BASE_URL=http://localhost
+
+# メール送信（Gmail）
+GMAIL_USER=your-email@gmail.com
+GMAIL_PASS=your-app-password
+
+# プッシュ通知（VAPID）
+VAPID_PUBLIC_KEY=...
+VAPID_PRIVATE_KEY=...
+VAPID_SUBJECT=mailto:your-email@gmail.com
+```
+
+> **Doppler を使う場合**: `.env` の代わりに Doppler CLI で環境変数を管理できます。
+
+### 3. Prisma クライアント生成
+
+```bash
+npx prisma generate
+```
+
+スキーマを変更した場合も再実行してください。
+
+### 4. マイグレーション（初回・スキーマ変更時）
+
+```bash
+npx prisma migrate dev
+```
+
+### 5. 開発サーバー起動
+
+```bash
+npm run dev
+```
+
+Doppler を使う場合:
+
+```bash
 npm run dev:doppler
+```
+
+## スクリプト一覧
+
+| スクリプト | 説明 |
+|-----------|------|
+| `npm run dev` | 開発サーバー起動（nodemon によるホットリロード） |
+| `npm run dev:doppler` | Doppler 経由で開発サーバー起動 |
+| `npm start` | 本番サーバー起動 |
+| `npm run migrate:deploy` | 本番マイグレーション実行 |
+| `npm run swagger` | swagger.json 自動生成 |
+
+## API ルート一覧
+
+| メソッド | パス | 説明 | 認証 |
+|---------|------|------|------|
+| POST | `/api/parents/register` | 親アカウント登録 | — |
+| POST | `/api/parents/login` | 親ログイン | — |
+| PATCH | `/api/parents/password` | パスワード変更 | 親 |
+| GET | `/api/children` | 子供一覧取得 | 親 |
+| POST | `/api/children` | 子供追加 | 親 |
+| POST | `/api/children/login` | 子供ログイン（あいことば認証） | — |
+| GET | `/api/tasks` | タスク一覧取得 | 親/子 |
+| POST | `/api/tasks` | タスク作成 | 親 |
+| PATCH | `/api/tasks/:id` | タスク編集 | 親 |
+| PATCH | `/api/tasks/:id/:label` | タスクステータス変更 | 親/子 |
+| DELETE | `/api/tasks/:id` | タスク削除 | 親 |
+| GET | `/api/pay` | 給与一覧取得 | 親 |
+| GET/PATCH | `/api/setting` | 設定取得・更新 | 親 |
+| POST | `/api/setup` | 初期設定 | 親 |
+| GET/POST | `/notification` | プッシュ通知登録・送信 | 親/子 |
+| GET | `/email/change` | メールアドレス変更 | — |
+
+## API ドキュメント
+
+開発サーバー起動後、以下の URL で Swagger UI を確認できます。
+
+```
+http://localhost:3000/api-docs
+```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,82 @@
-# React + Vite
+# frontend — ご褒美ポケット クライアント
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React + Vite で構築されたフロントエンドです。親用・子供用それぞれの画面と PWA 対応を提供します。
 
-Currently, two official plugins are available:
+## 技術スタック
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+| 技術 | バージョン | 用途 |
+|------|-----------|------|
+| React | 19.x | UI フレームワーク |
+| Vite | 6.x | ビルドツール |
+| Tailwind CSS | 4.x | スタイリング |
+| React Router | 7.x | クライアントサイドルーティング |
+| Axios | 1.x | HTTP クライアント |
+| Chart.js | 4.x | 給与グラフ描画 |
+| vite-plugin-pwa | 1.x | PWA 対応 |
+| react-toastify | 11.x | トースト通知 |
+| date-fns | 4.x | 日付操作 |
 
-## Expanding the ESLint configuration
+## ディレクトリ構成
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```
+frontend/src/
+├── components/
+│   ├── common/          # 汎用 UI コンポーネント（ボタン・入力欄等）
+│   ├── settings/        # 設定画面コンポーネント
+│   ├── tasks/           # タスク関連コンポーネント
+│   │   └── child/       # 子供用タスクコンポーネント
+│   └── ui/              # UI ライブラリ
+├── pages/               # ページコンポーネント
+├── config/              # 設定ファイル
+├── lib/                 # ライブラリ・ユーティリティ
+├── utils/               # 汎用ヘルパー関数
+└── App.jsx              # ルーター定義
+```
+
+## セットアップ
+
+### 1. 依存パッケージのインストール
+
+```bash
+npm install
+```
+
+### 2. 環境変数の設定
+
+`.env` ファイルをルートに作成し、以下の変数を設定してください。
+
+```env
+VITE_API_URL=http://localhost:3000
+```
+
+### 3. 開発サーバー起動
+
+```bash
+npm run dev
+```
+
+ブラウザで `http://localhost:5173` にアクセスしてください。
+
+## スクリプト一覧
+
+| スクリプト | 説明 |
+|-----------|------|
+| `npm run dev` | 開発サーバー起動（HMR 有効） |
+| `npm run build` | 本番用ビルド |
+| `npm run preview` | ビルド結果のプレビュー |
+| `npm run lint` | ESLint による静的解析 |
+
+## ページルート一覧
+
+| URL | ページ | 説明 |
+|-----|--------|------|
+| `/` | Login | 親アカウントログイン |
+| `/signup` | SignupPage | 親アカウント新規登録 |
+| `/top` | Top | 親用ダッシュボード（タスク一覧・給与管理） |
+| `/resetRequest` | PasswordResetRequest | パスワードリセット申請 |
+| `/reset` | PasswordReset | パスワードリセット |
+| `/childName` | ChildSignup | 子供の追加 |
+| `/childUrl` | ChildUrl | 子供用ログイン URL の表示 |
+| `/child/login/:childUUID` | Keyword | 子供ログイン（あいことば認証） |
+| `/child/top/:childUUID` | ChildTop | 子供用ダッシュボード（タスク一覧・給与確認） |
+| `*` | NotFound | 404 ページ |


### PR DESCRIPTION
## Summary
- `backend/README.md` を doppler メモから実用的なドキュメントに全面書き直し
- `frontend/README.md` を Vite テンプレートからプロジェクト固有の内容に全面書き直し

## 変更内容

### backend/README.md
- 技術スタック表（Express / Prisma / JWT / nodemailer / node-cron / web-push）
- ディレクトリ構成（controllers / routes / services / middlewares / lib / utils）
- セットアップ手順（npm install → 環境変数 → prisma generate → migrate dev → npm run dev）
- 環境変数一覧（DATABASE_URL / JWT_SECRET / GMAIL / VAPID 等）
- スクリプト一覧
- API ルート一覧（メソッド・パス・認証種別）
- Swagger UI の参照先（`/api-docs`）

### frontend/README.md
- 技術スタック表（React 19 / Vite / Tailwind CSS / React Router / Axios / Chart.js / PWA）
- ディレクトリ構成
- セットアップ手順（npm install → 環境変数 → npm run dev）
- スクリプト一覧
- ページルート一覧（URL・ページ名・説明）

## Test plan
- [ ] 記載されたセットアップ手順で実際に環境構築できること
- [ ] スクリプト名が package.json と一致していること
- [ ] ページルートが App.jsx のルーター定義と一致していること

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)